### PR TITLE
Gutenberg Coding Challenge (Edmund)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "@xwp/country-card-block",
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/api-fetch": "^6.13.0"
+			},
 			"devDependencies": {
 				"@wordpress/block-editor": "^8.1.1",
 				"@wordpress/blocks": "^11.2.1",
@@ -1823,7 +1826,6 @@
 			"version": "7.17.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
 			"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -3637,7 +3639,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
 			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-			"dev": true,
 			"dependencies": {
 				"@tannin/evaluate": "^1.2.0",
 				"@tannin/postfix": "^1.1.0"
@@ -3646,14 +3647,12 @@
 		"node_modules/@tannin/evaluate": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
-			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-			"dev": true
+			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
 		},
 		"node_modules/@tannin/plural-forms": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
 			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-			"dev": true,
 			"dependencies": {
 				"@tannin/compile": "^1.1.0"
 			}
@@ -3661,8 +3660,7 @@
 		"node_modules/@tannin/postfix": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
-			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-			"dev": true
+			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
@@ -4756,14 +4754,13 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.0.1.tgz",
-			"integrity": "sha512-rodFmGcnhI5gLKRueabLHiNrPpl/i+DCD23xg8/xs2Iyr47YFZZN4KB8WKaRVDxPZQJAB67IqMLs/h4U02HdmA==",
-			"dev": true,
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.13.0.tgz",
+			"integrity": "sha512-PwVhZI64naytQFmMc2veQYz6jA3DyAPe3cv3L499iKgigNt41fNHZpEz5tgZmpLJA0Avp9Ldy+izCzt9A0PKcQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.3.1",
-				"@wordpress/url": "^3.4.1"
+				"@wordpress/i18n": "^4.16.0",
+				"@wordpress/url": "^3.17.0"
 			},
 			"engines": {
 				"node": ">=12"
@@ -5407,10 +5404,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.3.1.tgz",
-			"integrity": "sha512-Eyc5YYX8010Ihr6Ab4lq9G7J9DmPiLnGf6C4WwEMf0iQ9SBw8hcp2TCwkSyC12DU7iY0o11FYGfgdGW3UpPiYA==",
-			"dev": true,
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.16.0.tgz",
+			"integrity": "sha512-KpY8KFp2/3TX6lKmffNmdkeaH9c4CN1iJ8SiCufjGgRCnVWmWe/HcEJ5OjhUvBnRkhsLMY7pvlXMU8Mh7nLxyA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -5431,13 +5427,12 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.3.1.tgz",
-			"integrity": "sha512-4xeGUOhZL+Xl97VPSEslWJxCjQPuK2I8AEJWe5cb1u/YOcgTzOav2QN7T7wYzt3Os5bfqNBmTFMfOr+1goFPrw==",
-			"dev": true,
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.16.0.tgz",
+			"integrity": "sha512-N7BChVVaQpt63e2Wgc0ST+ahUuhSjd6bqHqgIBnxZ4LU3c8tzd/etYjBqSM8RPcI9gSOM32ddlTnJgAxgntKaA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.3.1",
+				"@wordpress/hooks": "^3.16.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
@@ -5848,13 +5843,12 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.4.1.tgz",
-			"integrity": "sha512-EeE/qCTe2wYxvEhH4ygV8CONX7j1aQaZF5LUg+QHZ+cnV5Bo8SkcLZdOHqczwvljqwVnKc+ybzQx/WLE+APNSw==",
-			"dev": true,
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.17.0.tgz",
+			"integrity": "sha512-817geMi/DA5cPXO9tPHJB8g+MtI3xpA0s2/26paAciD5rPa/Y9BgTtfvPiR/pzKk+hQOxjNSw6dwb1bPGTmB1A==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"lodash": "^4.17.21"
+				"remove-accents": "^0.4.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -8924,7 +8918,6 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
 			"dependencies": {
 				"iconv-lite": "^0.6.2"
 			}
@@ -10965,7 +10958,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
 			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-			"dev": true,
 			"dependencies": {
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
@@ -11575,7 +11567,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -14763,8 +14754,7 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
@@ -15131,8 +15121,7 @@
 		"node_modules/memize": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
-			"dev": true
+			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
 		},
 		"node_modules/meow": {
 			"version": "6.1.1",
@@ -18474,8 +18463,7 @@
 		"node_modules/regenerator-runtime": {
 			"version": "0.13.9",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-			"dev": true
+			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
 		},
 		"node_modules/regenerator-transform": {
 			"version": "0.14.5",
@@ -18572,6 +18560,11 @@
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
 			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==",
 			"dev": true
+		},
+		"node_modules/remove-accents": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+			"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -18825,7 +18818,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -18844,8 +18836,7 @@
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"node_modules/sass": {
 			"version": "1.49.8",
@@ -19527,8 +19518,7 @@
 		"node_modules/sprintf-js": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-			"dev": true
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"node_modules/stable": {
 			"version": "0.1.8",
@@ -20354,7 +20344,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
 			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-			"dev": true,
 			"dependencies": {
 				"@tannin/plural-forms": "^1.1.0"
 			}
@@ -23184,7 +23173,6 @@
 			"version": "7.17.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
 			"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -24518,7 +24506,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
 			"integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-			"dev": true,
 			"requires": {
 				"@tannin/evaluate": "^1.2.0",
 				"@tannin/postfix": "^1.1.0"
@@ -24527,14 +24514,12 @@
 		"@tannin/evaluate": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
-			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-			"dev": true
+			"integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg=="
 		},
 		"@tannin/plural-forms": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
 			"integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-			"dev": true,
 			"requires": {
 				"@tannin/compile": "^1.1.0"
 			}
@@ -24542,8 +24527,7 @@
 		"@tannin/postfix": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
-			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-			"dev": true
+			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
@@ -25470,14 +25454,13 @@
 			}
 		},
 		"@wordpress/api-fetch": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.0.1.tgz",
-			"integrity": "sha512-rodFmGcnhI5gLKRueabLHiNrPpl/i+DCD23xg8/xs2Iyr47YFZZN4KB8WKaRVDxPZQJAB67IqMLs/h4U02HdmA==",
-			"dev": true,
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.13.0.tgz",
+			"integrity": "sha512-PwVhZI64naytQFmMc2veQYz6jA3DyAPe3cv3L499iKgigNt41fNHZpEz5tgZmpLJA0Avp9Ldy+izCzt9A0PKcQ==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.3.1",
-				"@wordpress/url": "^3.4.1"
+				"@wordpress/i18n": "^4.16.0",
+				"@wordpress/url": "^3.17.0"
 			}
 		},
 		"@wordpress/autop": {
@@ -25981,10 +25964,9 @@
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.3.1.tgz",
-			"integrity": "sha512-Eyc5YYX8010Ihr6Ab4lq9G7J9DmPiLnGf6C4WwEMf0iQ9SBw8hcp2TCwkSyC12DU7iY0o11FYGfgdGW3UpPiYA==",
-			"dev": true,
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.16.0.tgz",
+			"integrity": "sha512-KpY8KFp2/3TX6lKmffNmdkeaH9c4CN1iJ8SiCufjGgRCnVWmWe/HcEJ5OjhUvBnRkhsLMY7pvlXMU8Mh7nLxyA==",
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
@@ -25999,13 +25981,12 @@
 			}
 		},
 		"@wordpress/i18n": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.3.1.tgz",
-			"integrity": "sha512-4xeGUOhZL+Xl97VPSEslWJxCjQPuK2I8AEJWe5cb1u/YOcgTzOav2QN7T7wYzt3Os5bfqNBmTFMfOr+1goFPrw==",
-			"dev": true,
+			"version": "4.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.16.0.tgz",
+			"integrity": "sha512-N7BChVVaQpt63e2Wgc0ST+ahUuhSjd6bqHqgIBnxZ4LU3c8tzd/etYjBqSM8RPcI9gSOM32ddlTnJgAxgntKaA==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.3.1",
+				"@wordpress/hooks": "^3.16.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
@@ -26316,13 +26297,12 @@
 			}
 		},
 		"@wordpress/url": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.4.1.tgz",
-			"integrity": "sha512-EeE/qCTe2wYxvEhH4ygV8CONX7j1aQaZF5LUg+QHZ+cnV5Bo8SkcLZdOHqczwvljqwVnKc+ybzQx/WLE+APNSw==",
-			"dev": true,
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.17.0.tgz",
+			"integrity": "sha512-817geMi/DA5cPXO9tPHJB8g+MtI3xpA0s2/26paAciD5rPa/Y9BgTtfvPiR/pzKk+hQOxjNSw6dwb1bPGTmB1A==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"lodash": "^4.17.21"
+				"remove-accents": "^0.4.2"
 			}
 		},
 		"@wordpress/warning": {
@@ -28693,7 +28673,6 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
 			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "^0.6.2"
 			}
@@ -30232,7 +30211,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
 			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
@@ -30698,7 +30676,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
 			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
@@ -33056,8 +33033,7 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -33353,8 +33329,7 @@
 		"memize": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
-			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
-			"dev": true
+			"integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
 		},
 		"meow": {
 			"version": "6.1.1",
@@ -35794,8 +35769,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.9",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-			"dev": true
+			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.5",
@@ -35870,6 +35844,11 @@
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
 			"integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==",
 			"dev": true
+		},
+		"remove-accents": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+			"integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -36057,14 +36036,12 @@
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sass": {
 			"version": "1.49.8",
@@ -36599,8 +36576,7 @@
 		"sprintf-js": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-			"dev": true
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"stable": {
 			"version": "0.1.8",
@@ -37244,7 +37220,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
 			"integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-			"dev": true,
 			"requires": {
 				"@tannin/plural-forms": "^1.1.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11141,6 +11141,18 @@
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
+		"node_modules/got/node_modules/type-fest": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.9",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -20750,12 +20762,14 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -20787,6 +20801,20 @@
 			"dev": true,
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/uc.micro": {
@@ -30338,6 +30366,14 @@
 				"responselike": "^2.0.0",
 				"to-readable-stream": "^2.0.0",
 				"type-fest": "^0.10.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+					"dev": true
+				}
 			}
 		},
 		"graceful-fs": {
@@ -37526,10 +37562,12 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-			"dev": true
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -37555,6 +37593,13 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
+		},
+		"typescript": {
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"dev": true,
+			"peer": true
 		},
 		"uc.micro": {
 			"version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
 		"eslint": "^8.8.0",
 		"eslint-plugin-react-hooks": "^4.3.0",
 		"prettier": "npm:wp-prettier@2.2.1-beta-1"
+	},
+	"dependencies": {
+		"@wordpress/api-fetch": "^6.13.0"
 	}
 }

--- a/src/components/country-flag.js
+++ b/src/components/country-flag.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { getEmojiFlag } from '../utils';
+
+/**
+ * Country flag component
+ *
+ * @param {string} countryCode Country Code.
+ */
+export default function CountryFlag( { countryCode } ) {
+	const flag = getEmojiFlag( countryCode );
+	return (
+		<div className="xwp-country-card__media" data-emoji-flag={ flag }>
+			<div className="xwp-country-card-flag">{ flag }</div>
+		</div>
+	);
+}

--- a/src/components/country-greeting.js
+++ b/src/components/country-greeting.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import countries from '../../assets/countries.json';
+import continentNames from '../../assets/continent-names.json';
+import continents from '../../assets/continents.json';
+
+/**
+ * Country flag component. Renders countryName(countryCode), continentName e.g., Vietnam(VN), Asia.
+ *
+ * @param {string} countryCode Country Code.
+ */
+export default function CountryGreeting( { countryCode } ) {
+	return (
+		<>
+			<strong>{ countries[ countryCode ] }</strong> (
+			<span className="xwp-country-card__country-code">
+				{ countryCode }
+			</span>
+			), { continentNames[ continents[ countryCode ] ] }!
+		</>
+	);
+}

--- a/src/components/related-post.js
+++ b/src/components/related-post.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * RelatedPosts component.
+ *
+ * @param {Object} props Props
+ */
+export default function RelatedPosts( props ) {
+	const { relatedPosts } = props;
+	const hasRelatedPosts = relatedPosts?.length > 0;
+
+	return (
+		<div className="xwp-country-card__related-posts">
+			<h3 className="xwp-country-card__related-posts__heading">
+				{ hasRelatedPosts
+					? sprintf(
+							// translators: %d: number of related posts.
+							_n(
+								'There is %d related post:',
+								'There are %d related posts:',
+								relatedPosts.length
+							),
+							relatedPosts.length
+					  )
+					: __( 'There are no related posts.', 'xwp-country-card' ) }
+			</h3>
+			{ hasRelatedPosts && (
+				<ul className="xwp-country-card__related-posts-list">
+					{ relatedPosts.map( ( relatedPost, index ) => (
+						<li key={ index } className="related-post">
+							<a
+								className="link"
+								href={ relatedPost.link }
+								data-post-id={ relatedPost.id }
+							>
+								<h3 className="title">{ relatedPost.title }</h3>
+								<p className="excerpt">
+									{ relatedPost.excerpt }
+								</p>
+							</a>
+						</li>
+					) ) }
+				</ul>
+			) }
+		</div>
+	);
+}

--- a/src/edit.js
+++ b/src/edit.js
@@ -89,7 +89,7 @@ export default function Edit( { attributes, setAttributes } ) {
 					label={ __( 'XWP Country Card', 'xwp-country-card' ) }
 					isColumnLayout={ true }
 					instructions={ __(
-						'Type in a name of a contry you want to display on you site.',
+						'Type in a name of a country you want to display on you site.',
 						'xwp-country-card'
 					) }
 				>

--- a/src/edit.js
+++ b/src/edit.js
@@ -11,6 +11,7 @@ import {
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -29,8 +30,6 @@ export default function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const [ isPreview, setPreview ] = useState( false );
 
-	useEffect( () => setPreview( countryCode ), [ countryCode ] );
-
 	const handleChangeCountry = () => {
 		if ( isPreview ) setPreview( false );
 		else if ( countryCode ) setPreview( true );
@@ -45,26 +44,29 @@ export default function Edit( { attributes, setAttributes } ) {
 		}
 	};
 
+	useEffect( () => setPreview( countryCode ), [ countryCode ] );
+
 	useEffect( () => {
 		async function getRelatedPosts() {
 			const postId = window.location.href.match( /post=([\d]+)/ )[ 1 ];
-			const response = await window.fetch(
-				`/wp-json/wp/v2/posts?search=${ countries[ countryCode ] }&exclude=${ postId }`
-			);
+			try {
+				const response = await apiFetch( {
+					path: `/wp/v2/posts?search=${ countries[ countryCode ] }&exclude=${ postId }`,
+				} );
 
-			if ( ! response.ok )
-				throw new Error( `HTTP error! Status: ${ response.status }` );
-
-			const posts = await response.json();
-
-			setAttributes( {
-				relatedPosts:
-					posts?.map( ( relatedPost ) => ( {
-						...relatedPost,
-						title: relatedPost.title?.rendered || relatedPost.link,
-						excerpt: relatedPost.excerpt?.rendered || '',
-					} ) ) || [],
-			} );
+				setAttributes( {
+					relatedPosts:
+						response?.map( ( relatedPost ) => ( {
+							...relatedPost,
+							title:
+								relatedPost.title?.rendered || relatedPost.link,
+							excerpt: relatedPost.excerpt?.rendered || '',
+						} ) ) || [],
+				} );
+			} catch ( err ) {
+				// TODO display error message
+				console.log( err.message );
+			}
 		}
 
 		getRelatedPosts();

--- a/src/edit.js
+++ b/src/edit.js
@@ -18,9 +18,6 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
 import countries from '../assets/countries.json';
 import { getCountryDropdownOptions } from './utils';
 import Preview from './preview';

--- a/src/edit.js
+++ b/src/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { edit, globe } from '@wordpress/icons';
-import { BlockControls } from '@wordpress/block-editor';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ComboboxControl,
 	Placeholder,
@@ -26,12 +26,13 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 	const { countryCode, relatedPosts } = attributes;
+	const blockProps = useBlockProps();
 	const options = Object.keys( countries ).map( ( code ) => ( {
 		value: code,
 		label: getEmojiFlag( code ) + '  ' + countries[ code ] + ' — ' + code,
 	} ) );
 
-	const [ isPreview, setPreview ] = useState();
+	const [ isPreview, setPreview ] = useState( false );
 
 	useEffect( () => setPreview( countryCode ), [ countryCode ] );
 
@@ -76,41 +77,41 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	return (
 		<>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton
-						label={ __( 'Change Country', 'xwp-country-card' ) }
-						icon={ edit }
-						onClick={ handleChangeCountry }
-						disabled={ ! Boolean( countryCode ) }
+			<div { ...blockProps }>
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							label={ __( 'Change Country', 'xwp-country-card' ) }
+							icon={ edit }
+							onClick={ handleChangeCountry }
+							disabled={ ! Boolean( countryCode ) }
+						/>
+					</ToolbarGroup>
+				</BlockControls>
+
+				<Placeholder
+					icon={ globe }
+					label={ __( 'XWP Country Card', 'xwp-country-card' ) }
+					isColumnLayout={ true }
+					instructions={ __(
+						'Type in a name of a contry you want to display on you site.',
+						'xwp-country-card'
+					) }
+				>
+					<ComboboxControl
+						label={ __( 'Country', 'xwp-country-card' ) }
+						hideLabelFromVision
+						options={ options }
+						value={ countryCode }
+						onChange={ handleChangeCountryCode }
+						allowReset={ true }
 					/>
-				</ToolbarGroup>
-			</BlockControls>
-			<div>
-				{ isPreview ? (
+				</Placeholder>
+				{ isPreview && (
 					<Preview
 						countryCode={ countryCode }
 						relatedPosts={ relatedPosts }
 					/>
-				) : (
-					<Placeholder
-						icon={ globe }
-						label={ __( 'XWP Country Card', 'xwp-country-card' ) }
-						isColumnLayout={ true }
-						instructions={ __(
-							'Type in a name of a contry you want to display on you site.',
-							'xwp-country-card'
-						) }
-					>
-						<ComboboxControl
-							label={ __( 'Country', 'xwp-country-card' ) }
-							hideLabelFromVision
-							options={ options }
-							value={ countryCode }
-							onChange={ handleChangeCountryCode }
-							allowReset={ true }
-						/>
-					</Placeholder>
 				) }
 			</div>
 		</>

--- a/src/edit.js
+++ b/src/edit.js
@@ -12,6 +12,7 @@ import {
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ export default function Edit( { attributes, setAttributes } ) {
 	const { countryCode, relatedPosts } = attributes;
 	const blockProps = useBlockProps();
 	const [ isPreview, setPreview ] = useState( false );
+	const postId = useSelect( 'core/editor' ).getCurrentPostId();
 
 	const handleChangeCountry = () => {
 		if ( isPreview ) setPreview( false );
@@ -48,7 +50,6 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	useEffect( () => {
 		async function getRelatedPosts() {
-			const postId = window.location.href.match( /post=([\d]+)/ )[ 1 ];
 			try {
 				const response = await apiFetch( {
 					path: `/wp/v2/posts?search=${ countries[ countryCode ] }&exclude=${ postId }`,
@@ -63,14 +64,11 @@ export default function Edit( { attributes, setAttributes } ) {
 							excerpt: relatedPost.excerpt?.rendered || '',
 						} ) ) || [],
 				} );
-			} catch ( err ) {
-				// TODO display error message
-				console.log( err.message );
-			}
+			} catch ( err ) {}
 		}
 
 		getRelatedPosts();
-	}, [ countryCode, setAttributes ] );
+	}, [ countryCode, setAttributes, postId ] );
 
 	return (
 		<>

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,19 +1,35 @@
-import countries from '../assets/countries.json';
-import './editor.scss';
+/**
+ * WordPress dependencies
+ */
 import { edit, globe } from '@wordpress/icons';
 import { BlockControls } from '@wordpress/block-editor';
-import { ComboboxControl, Placeholder, ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { getEmojiFlag } from './utils';
+import {
+	ComboboxControl,
+	Placeholder,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import countries from '../assets/countries.json';
+import { getEmojiFlag } from './utils';
 import Preview from './preview';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 	const { countryCode, relatedPosts } = attributes;
-	const options = Object.keys(countries).map(code => ({
-        value: code,
-        label:  getEmojiFlag( code ) + '  ' + countries[code] + ' — ' + code
-	}));
+	const options = Object.keys( countries ).map( ( code ) => ( {
+		value: code,
+		label: getEmojiFlag( code ) + '  ' + countries[ code ] + ' — ' + code,
+	} ) );
 
 	const [ isPreview, setPreview ] = useState();
 
@@ -24,7 +40,7 @@ export default function Edit( { attributes, setAttributes } ) {
 		else if ( countryCode ) setPreview( true );
 	};
 
-	const handleChangeCountryCode = newCountryCode => {
+	const handleChangeCountryCode = ( newCountryCode ) => {
 		if ( newCountryCode && countryCode !== newCountryCode ) {
 			setAttributes( {
 				countryCode: newCountryCode,
@@ -36,7 +52,9 @@ export default function Edit( { attributes, setAttributes } ) {
 	useEffect( () => {
 		async function getRelatedPosts() {
 			const postId = window.location.href.match( /post=([\d]+)/ )[ 1 ];
-			const response = await window.fetch( `/wp-json/wp/v2/posts?search=${ countries[ countryCode ] }&exclude=${ postId }` );
+			const response = await window.fetch(
+				`/wp-json/wp/v2/posts?search=${ countries[ countryCode ] }&exclude=${ postId }`
+			);
 
 			if ( ! response.ok )
 				throw new Error( `HTTP error! Status: ${ response.status }` );
@@ -44,38 +62,56 @@ export default function Edit( { attributes, setAttributes } ) {
 			const posts = await response.json();
 
 			setAttributes( {
-				relatedPosts: posts?.map( ( relatedPost ) => ( {
-					...relatedPost,
-					title: relatedPost.title?.rendered || relatedPost.link,
-					excerpt: relatedPost.excerpt?.rendered || '',
-				} ) ) || [],
+				relatedPosts:
+					posts?.map( ( relatedPost ) => ( {
+						...relatedPost,
+						title: relatedPost.title?.rendered || relatedPost.link,
+						excerpt: relatedPost.excerpt?.rendered || '',
+					} ) ) || [],
 			} );
 		}
 
 		getRelatedPosts();
-	}, [countryCode, setAttributes] );
+	}, [ countryCode, setAttributes ] );
 
 	return (
 		<>
 			<BlockControls>
 				<ToolbarGroup>
-						<ToolbarButton label={ __( 'Change Country', 'xwp-country-card' ) }
-							icon={ edit } onClick={ handleChangeCountry } disabled={ ! Boolean( countryCode ) } />
+					<ToolbarButton
+						label={ __( 'Change Country', 'xwp-country-card' ) }
+						icon={ edit }
+						onClick={ handleChangeCountry }
+						disabled={ ! Boolean( countryCode ) }
+					/>
 				</ToolbarGroup>
 			</BlockControls>
 			<div>
-				{ isPreview ? <Preview countryCode={ countryCode } relatedPosts={ relatedPosts }/> : <Placeholder icon={ globe } label={ __( 'XWP Country Card', 'xwp-country-card' ) }
-								 isColumnLayout={ true }
-								 instructions={ __( 'Type in a name of a contry you want to display on you site.', 'xwp-country-card' ) }>
+				{ isPreview ? (
+					<Preview
+						countryCode={ countryCode }
+						relatedPosts={ relatedPosts }
+					/>
+				) : (
+					<Placeholder
+						icon={ globe }
+						label={ __( 'XWP Country Card', 'xwp-country-card' ) }
+						isColumnLayout={ true }
+						instructions={ __(
+							'Type in a name of a contry you want to display on you site.',
+							'xwp-country-card'
+						) }
+					>
 						<ComboboxControl
 							label={ __( 'Country', 'xwp-country-card' ) }
-                            hideLabelFromVision
+							hideLabelFromVision
 							options={ options }
 							value={ countryCode }
 							onChange={ handleChangeCountryCode }
-                            allowReset={true}
+							allowReset={ true }
 						/>
-					</Placeholder> }
+					</Placeholder>
+				) }
 			</div>
 		</>
 	);

--- a/src/edit.js
+++ b/src/edit.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import countries from '../assets/countries.json';
-import { getEmojiFlag } from './utils';
+import { getCountryDropdownOptions } from './utils';
 import Preview from './preview';
 
 /**
@@ -27,11 +27,6 @@ import './editor.scss';
 export default function Edit( { attributes, setAttributes } ) {
 	const { countryCode, relatedPosts } = attributes;
 	const blockProps = useBlockProps();
-	const options = Object.keys( countries ).map( ( code ) => ( {
-		value: code,
-		label: getEmojiFlag( code ) + '  ' + countries[ code ] + ' — ' + code,
-	} ) );
-
 	const [ isPreview, setPreview ] = useState( false );
 
 	useEffect( () => setPreview( countryCode ), [ countryCode ] );
@@ -101,7 +96,7 @@ export default function Edit( { attributes, setAttributes } ) {
 					<ComboboxControl
 						label={ __( 'Country', 'xwp-country-card' ) }
 						hideLabelFromVision
-						options={ options }
+						options={ getCountryDropdownOptions() }
 						value={ countryCode }
 						onChange={ handleChangeCountryCode }
 						allowReset={ true }

--- a/src/edit.js
+++ b/src/edit.js
@@ -10,10 +10,14 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
+/**
+ * Internal dependencies
+ */
 /**
  * Internal dependencies
  */
@@ -31,6 +35,8 @@ export default function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const [ isPreview, setPreview ] = useState( false );
 	const postId = useSelect( 'core/editor' ).getCurrentPostId();
+
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const handleChangeCountry = () => {
 		if ( isPreview ) setPreview( false );
@@ -64,11 +70,26 @@ export default function Edit( { attributes, setAttributes } ) {
 							excerpt: relatedPost.excerpt?.rendered || '',
 						} ) ) || [],
 				} );
-			} catch ( err ) {}
+			} catch ( err ) {
+				createErrorNotice(
+					sprintf(
+						// Translators: %s: Error message
+						__(
+							'Unable to retrieve related posts: %s',
+							'xwp-country-card'
+						),
+						err.message
+					),
+					{
+						type: 'snackbar',
+						explicitDismiss: true,
+					}
+				);
+			}
 		}
 
 		getRelatedPosts();
-	}, [ countryCode, setAttributes, postId ] );
+	}, [ countryCode, setAttributes, postId, createErrorNotice ] );
 
 	return (
 		<>

--- a/src/edit.js
+++ b/src/edit.js
@@ -36,8 +36,11 @@ export default function Edit( { attributes, setAttributes } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const handleChangeCountry = () => {
-		if ( isPreview ) setPreview( false );
-		else if ( countryCode ) setPreview( true );
+		if ( isPreview ) {
+			setPreview( false );
+		} else if ( countryCode ) {
+			setPreview( true );
+		}
 	};
 
 	const handleChangeCountryCode = ( newCountryCode ) => {
@@ -101,25 +104,27 @@ export default function Edit( { attributes, setAttributes } ) {
 						/>
 					</ToolbarGroup>
 				</BlockControls>
+				{ ! isPreview && (
+					<Placeholder
+						icon={ globe }
+						label={ __( 'XWP Country Card', 'xwp-country-card' ) }
+						isColumnLayout={ true }
+						instructions={ __(
+							'Type in a name of a country you want to display on you site.',
+							'xwp-country-card'
+						) }
+					>
+						<ComboboxControl
+							label={ __( 'Country', 'xwp-country-card' ) }
+							hideLabelFromVision
+							options={ getCountryDropdownOptions() }
+							value={ countryCode }
+							onChange={ handleChangeCountryCode }
+							allowReset={ true }
+						/>
+					</Placeholder>
+				) }
 
-				<Placeholder
-					icon={ globe }
-					label={ __( 'XWP Country Card', 'xwp-country-card' ) }
-					isColumnLayout={ true }
-					instructions={ __(
-						'Type in a name of a country you want to display on you site.',
-						'xwp-country-card'
-					) }
-				>
-					<ComboboxControl
-						label={ __( 'Country', 'xwp-country-card' ) }
-						hideLabelFromVision
-						options={ getCountryDropdownOptions() }
-						value={ countryCode }
-						onChange={ handleChangeCountryCode }
-						allowReset={ true }
-					/>
-				</Placeholder>
 				{ isPreview && (
 					<Preview
 						countryCode={ countryCode }

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -1,11 +1,3 @@
-.wp-block-xwp-country-card {
-
-	display: flex;
-	gap: 1.5em;
-	align-items: flex-start;
-
-	 .components-form-token-field__suggestion {
-		white-space: pre-wrap;
-	}
+.wp-block-xwp-country-card .components-form-token-field__suggestion {
+	white-space: pre-wrap;
 }
-

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -1,3 +1,11 @@
-.wp-block-xwp-country-card .components-form-token-field__suggestion {
-	white-space: pre-wrap;
+.wp-block-xwp-country-card {
+
+	display: flex;
+	gap: 1.5em;
+	align-items: flex-start;
+
+	 .components-form-token-field__suggestion {
+		white-space: pre-wrap;
+	}
 }
+

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,13 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import edit from './edit';
 import save from './save';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 registerBlockType( 'xwp/country-card', {
 	edit,

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,51 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import countries from '../assets/countries.json';
 import continentNames from '../assets/continent-names.json';
 import continents from '../assets/continents.json';
 import { getEmojiFlag } from './utils';
-import { __, sprintf } from '@wordpress/i18n';
 
 export default function Preview( { countryCode, relatedPosts } ) {
 	if ( ! countryCode ) return null;
 
 	const emojiFlag = getEmojiFlag( countryCode ),
-	      hasRelatedPosts = relatedPosts?.length > 0;
+		hasRelatedPosts = relatedPosts?.length > 0;
 
 	return (
 		<div className="xwp-country-card">
-			<div className="xwp-country-card__media" data-emoji-flag={ emojiFlag }>
-				<div className="xwp-country-card-flag">
-					{ emojiFlag }
-				</div>
+			<div
+				className="xwp-country-card__media"
+				data-emoji-flag={ emojiFlag }
+			>
+				<div className="xwp-country-card-flag">{ emojiFlag }</div>
 			</div>
 			<h3 className="xwp-country-card__heading">
-				{ __( 'Hello from' ) }
-				{ ' ' }
-				<strong>{ countries[countryCode] }</strong>
-				{ ' ' }
-				(<span className="xwp-country-card__country-code">{ countryCode }</span>),
-				{ ' ' }
-				{ continentNames[continents[countryCode]] }!
+				{ __( 'Hello from' ) }{ ' ' }
+				<strong>{ countries[ countryCode ] }</strong> (
+				<span className="xwp-country-card__country-code">
+					{ countryCode }
+				</span>
+				), { continentNames[ continents[ countryCode ] ] }!
 			</h3>
 			<div className="xwp-country-card__related-posts">
 				<h3 className="xwp-country-card__related-posts__heading">
-					{ hasRelatedPosts ? sprintf( __( 'There are %d related posts:' ), relatedPosts.length ) : __( 'There are no related posts.' ) }
+					{ hasRelatedPosts
+						? sprintf(
+								__( 'There are %d related posts:' ),
+								relatedPosts.length
+						  )
+						: __( 'There are no related posts.' ) }
 				</h3>
 				{ hasRelatedPosts && (
 					<ul className="xwp-country-card__related-posts-list">
 						{ relatedPosts.map( ( relatedPost, index ) => (
 							<li key={ index } className="related-post">
-									<a
-										className="link"
-										href={ relatedPost.link }
-										data-post-id={ relatedPost.id }
-									>
-										<h3 className="title">
-											{ relatedPost.title }
-										</h3>
-										<p className="excerpt">
-											{ relatedPost.excerpt }
-										</p>
-									</a>
+								<a
+									className="link"
+									href={ relatedPost.link }
+									data-post-id={ relatedPost.id }
+								>
+									<h3 className="title">
+										{ relatedPost.title }
+									</h3>
+									<p className="excerpt">
+										{ relatedPost.excerpt }
+									</p>
+								</a>
 							</li>
 						) ) }
 					</ul>

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,76 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import countries from '../assets/countries.json';
-import continentNames from '../assets/continent-names.json';
-import continents from '../assets/continents.json';
-import { getEmojiFlag } from './utils';
+import CountryFlag from './components/country-flag';
+import RelatedPosts from './components/related-post';
+import CountryGreeting from './components/country-greeting';
 
 export default function Preview( { countryCode, relatedPosts } ) {
 	if ( ! countryCode ) return null;
 
-	const emojiFlag = getEmojiFlag( countryCode ),
-		hasRelatedPosts = relatedPosts?.length > 0;
-
 	return (
 		<div className="xwp-country-card">
-			<div
-				className="xwp-country-card__media"
-				data-emoji-flag={ emojiFlag }
-			>
-				<div className="xwp-country-card-flag">{ emojiFlag }</div>
-			</div>
+			<CountryFlag countryCode={ countryCode } />
 			<h3 className="xwp-country-card__heading">
 				{ __( 'Hello from', 'xwp-country-card' ) }{ ' ' }
-				<strong>{ countries[ countryCode ] }</strong> (
-				<span className="xwp-country-card__country-code">
-					{ countryCode }
-				</span>
-				), { continentNames[ continents[ countryCode ] ] }!
+				<CountryGreeting countryCode={ countryCode } />
 			</h3>
-			<div className="xwp-country-card__related-posts">
-				<h3 className="xwp-country-card__related-posts__heading">
-					{ hasRelatedPosts
-						? sprintf(
-								// translators: %d: number of related posts.
-								_n(
-									'There is %d related post:',
-									'There are %d related posts:',
-									relatedPosts.length
-								),
-								relatedPosts.length
-						  )
-						: __(
-								'There are no related posts.',
-								'xwp-country-card'
-						  ) }
-				</h3>
-				{ hasRelatedPosts && (
-					<ul className="xwp-country-card__related-posts-list">
-						{ relatedPosts.map( ( relatedPost, index ) => (
-							<li key={ index } className="related-post">
-								<a
-									className="link"
-									href={ relatedPost.link }
-									data-post-id={ relatedPost.id }
-								>
-									<h3 className="title">
-										{ relatedPost.title }
-									</h3>
-									<p className="excerpt">
-										{ relatedPost.excerpt }
-									</p>
-								</a>
-							</li>
-						) ) }
-					</ul>
-				) }
-			</div>
+
+			<RelatedPosts relatedPosts={ relatedPosts } />
 		</div>
 	);
 }

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -37,7 +37,12 @@ export default function Preview( { countryCode, relatedPosts } ) {
 				<h3 className="xwp-country-card__related-posts__heading">
 					{ hasRelatedPosts
 						? sprintf(
-								__( 'There are %d related posts:' ),
+								// translators: %d: number of related posts.
+								_n(
+									'There is %d related post:',
+									'There are %d related posts:',
+									relatedPosts.length
+								),
 								relatedPosts.length
 						  )
 						: __( 'There are no related posts.' ) }

--- a/src/preview.js
+++ b/src/preview.js
@@ -26,7 +26,7 @@ export default function Preview( { countryCode, relatedPosts } ) {
 				<div className="xwp-country-card-flag">{ emojiFlag }</div>
 			</div>
 			<h3 className="xwp-country-card__heading">
-				{ __( 'Hello from' ) }{ ' ' }
+				{ __( 'Hello from', 'xwp-country-card' ) }{ ' ' }
 				<strong>{ countries[ countryCode ] }</strong> (
 				<span className="xwp-country-card__country-code">
 					{ countryCode }
@@ -45,7 +45,10 @@ export default function Preview( { countryCode, relatedPosts } ) {
 								),
 								relatedPosts.length
 						  )
-						: __( 'There are no related posts.' ) }
+						: __(
+								'There are no related posts.',
+								'xwp-country-card'
+						  ) }
 				</h3>
 				{ hasRelatedPosts && (
 					<ul className="xwp-country-card__related-posts-list">

--- a/src/save.js
+++ b/src/save.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import Preview from './preview';
 
 export default function Save( { attributes } ) {

--- a/src/save.js
+++ b/src/save.js
@@ -1,11 +1,17 @@
 /**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import Preview from './preview';
 
 export default function Save( { attributes } ) {
+	const blockProps = useBlockProps.save();
 	return (
-		<div>
+		<div { ...blockProps }>
 			<Preview { ...attributes } />
 		</div>
 	);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import countries from '../assets/countries.json';
+
+/**
  * Retrieve emoji flag based on country code
  *
  * @param {string} countryCode Country Code
@@ -11,4 +16,16 @@ export function getEmojiFlag( countryCode ) {
 			.split( '' )
 			.map( ( char ) => 127397 + char.charCodeAt() )
 	);
+}
+
+/**
+ * Retrieve the options for populating the country dropdown.
+ *
+ * @return {Array} The country dropdown options.
+ */
+export function getCountryDropdownOptions() {
+	return Object.keys( countries ).map( ( code ) => ( {
+		value: code,
+		label: getEmojiFlag( code ) + '  ' + countries[ code ] + ' — ' + code,
+	} ) );
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,9 @@
+/**
+ * Retrieve emoji flag based on country code
+ *
+ * @param {string} countryCode Country Code
+ * @return {string} The given content with some characters escaped.
+ */
 export function getEmojiFlag( countryCode ) {
 	return String.fromCodePoint(
 		...countryCode


### PR DESCRIPTION
This PR includes the following enhancements and refactoring done to the **Country Card Block**:

### Enhancements
- Properly format code according to the `@wordpress/eslint-plugin/recommended` plugin 28cc9c9d33442cb6bc2ac71cab916e10ddb37f56
- Add JSDoc to functions
- Add the ability to display singular or pluralised string e17cd14cec505eca2d8642c187b61bfbf2c608b2
- Add domain to all translatable strings bbbe868c60ecad11a5664a3a25771e87856b1afb
- Use the [apiFetch](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-api-fetch/) library to perform data fetching 2ce29d847a9c099693263345f4861d889125f38f
- Use a more declarative approach to retrieve the post ID b9a487a5cf6cf8b9c84bfe98be6b216d06fd6e3c
- Display error messages in a "Snackbar" component 89c34423ff3bb0970ada715ba2171e0a2446ab16
- Refactor several elements in `<Preview />` into its own component f56b036d8fc32bfbb53583713eab9c6fd50a1c9a
- Move the logic for retrieving the country dropdown options into its own utility. Since `countries` is not going to change, there is no point in running the logic on every re-render of `<Edit />` 3e86f65d9003b73f7fbd65912a68127f505c273e

### Bug fixes
- Fix issue where the Country Card Block cannot be selected https://github.com/xwp-hiring/gutenberg-coding-challenge/commit/c9d75beb144405b4a9ccffeb14021c995bdae43c

### Possible improvements

